### PR TITLE
feat/#1-in-app-notification: FCM 토큰 등록 기능 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    id("com.google.gms.google-services")
 }
 
 android {
@@ -67,4 +68,8 @@ dependencies {
     val nav_version = "2.7.7"
     implementation("androidx.navigation:navigation-fragment-ktx:$nav_version")
     implementation("androidx.navigation:navigation-ui-ktx:$nav_version")
+
+    implementation(platform("com.google.firebase:firebase-bom:33.7.0"))
+    implementation("com.google.firebase:firebase-messaging")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.project.unimate">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:allowBackup="true"
@@ -11,15 +15,25 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Unimate">
+
         <activity
             android:name=".MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- ✅ FCM 수신 서비스 -->
+        <service
+            android:name=".UnimateFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/project/unimate/MainActivity.kt
+++ b/app/src/main/java/com/project/unimate/MainActivity.kt
@@ -1,20 +1,141 @@
 package com.project.unimate
 
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
+import android.util.Log
+import android.widget.TextView
+import androidx.activity.ComponentActivity
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import com.google.firebase.messaging.FirebaseMessaging
+import okhttp3.*
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.IOException
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : ComponentActivity() {
+
+    private val TAG = "UnimateFCM"
+    private val client = OkHttpClient()
+
+    private val BASE_URL = "https://seok-hwan1.duckdns.org"
+    private val TEST_USER_ID = "1"
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
+
+        // ✅ 네 레이아웃 사용 (Hello World TextView 있음)
         setContentView(R.layout.activity_main)
-        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
-            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
-            insets
+
+        Log.d(TAG, "앱 시작")
+
+        requestNotificationPermissionIfNeeded()
+        fetchFcmTokenAndRegister()
+
+        // ✅ 알림 클릭/딥링크로 들어온 인텐트 처리
+        handlePushIntent(intent)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        handlePushIntent(intent)
+    }
+
+    private fun handlePushIntent(intent: Intent?) {
+        if (intent == null) return
+
+        val screen = intent.getStringExtra("push_screen")
+        val alarmId = intent.getStringExtra("push_alarm_id")
+
+        val tv = findViewById<TextView>(R.id.tvLog)
+        tv.text = "앱 시작(푸시 아님이면 이게 보임)"
+
+        if (screen != null || alarmId != null) {
+            val msg = "PushClick: screen=$screen alarmId=$alarmId"
+            Log.d(TAG, msg)
+            tv.text = msg
+
+            // TODO: 여기서 네가 원하는 화면으로 이동(추후)
+            // 예) if (screen == "alarm_detail" && alarmId != null) { ... }
+        } else {
+            tv.text = "Hello World!"
         }
+    }
+
+    private fun requestNotificationPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val granted = ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+
+            if (!granted) {
+                ActivityCompat.requestPermissions(
+                    this,
+                    arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                    1001
+                )
+            } else {
+                Log.d(TAG, "알림 권한: 이미 허용됨")
+            }
+        } else {
+            Log.d(TAG, "알림 권한: Android 13 미만은 런타임 권한 없음")
+        }
+    }
+
+    private fun fetchFcmTokenAndRegister() {
+        Log.d(TAG, "FCM 토큰 요청중...")
+
+        FirebaseMessaging.getInstance().token
+            .addOnSuccessListener { token ->
+                Log.d(TAG, "FCM_TOKEN=$token")
+                registerTokenToServer(token)
+            }
+            .addOnFailureListener { e ->
+                Log.e(TAG, "FCM 토큰 발급 실패", e)
+            }
+    }
+
+    private fun registerTokenToServer(token: String) {
+        val url = "$BASE_URL/api/v1/fcm/token"
+
+        val json = """
+            {
+              "token": "$token",
+              "deviceId": "emu-01",
+              "platform": "ANDROID"
+            }
+        """.trimIndent()
+
+        val req = Request.Builder()
+            .url(url)
+            .addHeader("Content-Type", "application/json")
+            .addHeader("X-USER-ID", TEST_USER_ID)
+            .post(json.toRequestBody("application/json; charset=utf-8".toMediaType()))
+            .build()
+
+        client.newCall(req).enqueue(object : Callback {
+            override fun onFailure(call: Call, e: IOException) {
+                Log.e(TAG, "토큰 등록 실패(네트워크)", e)
+            }
+
+            override fun onResponse(call: Call, response: Response) {
+                val code = response.code
+                val body = response.body?.string()
+                response.close()
+
+                Log.d(TAG, "토큰 등록 응답 code=$code body=$body")
+
+                if (code in 200..299) {
+                    Log.d(TAG, "✅ 토큰 등록 성공")
+                } else {
+                    Log.e(TAG, "❌ 토큰 등록 실패(서버 응답 비정상)")
+                }
+            }
+        })
     }
 }

--- a/app/src/main/java/com/project/unimate/UnimateFirebaseMessagingService.kt
+++ b/app/src/main/java/com/project/unimate/UnimateFirebaseMessagingService.kt
@@ -1,0 +1,78 @@
+package com.project.unimate
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+
+class UnimateFirebaseMessagingService : FirebaseMessagingService() {
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        val data = message.data
+
+        // data-only를 우선(라우팅에 필요)
+        val title = data["title"] ?: message.notification?.title ?: "Unimate"
+        val body = data["body"] ?: message.notification?.body ?: ""
+        val screen = data["screen"] ?: "home"
+        val alarmId = data["alarmId"]
+
+        Log.d(TAG, "onMessageReceived title=$title body=$body screen=$screen alarmId=$alarmId")
+
+        showNotification(title, body, screen, alarmId)
+    }
+
+    private fun showNotification(title: String, body: String, screen: String, alarmId: String?) {
+        ensureChannel()
+
+        val intent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra(EXTRA_PUSH_SCREEN, screen)
+            putExtra(EXTRA_PUSH_ALARM_ID, alarmId)
+        }
+
+        // ✅ requestCode 고정 금지
+        val requestCode = (System.currentTimeMillis() % 100000).toInt()
+
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            requestCode,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setAutoCancel(true)
+            .setContentIntent(pendingIntent)
+            .build()
+
+        val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        nm.notify(requestCode, notification)
+    }
+
+    private fun ensureChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (nm.getNotificationChannel(CHANNEL_ID) != null) return
+
+        nm.createNotificationChannel(
+            NotificationChannel(CHANNEL_ID, "Unimate", NotificationManager.IMPORTANCE_DEFAULT)
+        )
+    }
+
+    companion object {
+        private const val TAG = "UnimateFCM"
+        private const val CHANNEL_ID = "unimate_default"
+
+        const val EXTRA_PUSH_SCREEN = "push_screen"
+        const val EXTRA_PUSH_ALARM_ID = "push_alarm_id"
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,6 +8,7 @@
     tools:context=".MainActivity">
 
     <TextView
+        android:id="@+id/tvLog"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Hello World!"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,4 +2,5 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
+    id("com.google.gms.google-services") version "4.4.2" apply false
 }


### PR DESCRIPTION
# Frontend 구현 내용 & 테스트 방법 (Kotlin / Android)

> 이번 작업의 목표는 **FCM 푸시 알림이 “도착”하고**, 사용자가 알림을 **클릭했을 때 앱이 어떤 화면(screen)으로 가야 하는지**를 앱이 인지하도록 만드는 것입니다.  
> 현재 단계에서는 “화면 이동”까지는 최소화하고, **클릭 정보(screen/alarmId)를 TextView(tvLog)에 출력**하여 동작을 확실히 검증합니다.

---

## 1) 구현 내용

### 1-1. 앱 실행 시 알림 권한 요청 (Android 13+)
- Android 13(API 33)부터는 알림을 띄우려면 **POST_NOTIFICATIONS 권한**을 사용자에게 받아야 합니다.
- 그래서 앱이 실행되면 권한을 확인하고, 없다면 권한 팝업을 띄우도록 구현했습니다.

**왜 필요?**
- 권한이 없으면 푸시가 와도 알림이 표시되지 않아 “푸시가 안 오는 것처럼” 보일 수 있습니다.

---

### 1-2. FCM 토큰 발급 & 로그 출력
- 앱에서 FirebaseMessaging을 통해 **FCM 토큰(디바이스 식별값)** 을 발급받습니다.
- 성공하면 로그캣에 `FCM_TOKEN=...` 형태로 출력하도록 했습니다.

**왜 필요?**
- 백엔드가 이 토큰을 대상으로 푸시를 보내기 때문에, “푸시가 갈 대상”을 알기 위한 핵심 값입니다.

---

### 1-3. FCM 토큰을 백엔드 서버에 등록
- 발급받은 토큰을 백엔드 API로 등록합니다.
- 요청 예시:
  - `POST /api/v1/fcm/token/me`
  - body: `token`

**왜 필요?**
- 백엔드는 “어떤 유저가 어떤 디바이스 토큰을 쓰는지” DB에 저장해두고,
  특정 이벤트(알림 발생) 때 해당 토큰으로 푸시를 보낼 수 있습니다.

---

### 1-4. 푸시 수신 시 알림 표시 (FirebaseMessagingService)
- `UnimateFirebaseMessagingService`에서 메시지를 받으면 알림(Notification)을 생성합니다.
- 특히 **data payload** 를 우선으로 읽습니다.
  - `title`, `body`, `screen`, `alarmId`

**왜 data payload를 쓰나?**
- 앱이 “알림을 클릭했을 때 어디로 이동해야 하는지”를 알기 위해서는 `screen`, `alarmId` 같은 값이 필요합니다.
- 이 값들은 **notification-only**에 넣기 애매하고, 라우팅에는 **data payload가 안정적**입니다.

---

### 1-5. 알림 클릭 시 앱에서 클릭 정보를 읽기
- 알림 클릭 시 `MainActivity`로 이동하도록 `PendingIntent`를 설정했습니다.
- 이 때 Intent에 아래 값을 담아 전달합니다.

- `push_screen`: 어떤 화면으로 가야 하는지
- `push_alarm_id`: 상세 화면에 필요한 id(선택)

그리고 `MainActivity`는 들어온 Intent에서 위 값을 읽어서 `tvLog`에 표시합니다.

**현재는 “화면 이동” 대신 tvLog 표시로 검증**
- 추후에는 `screen`에 따라 Activity/Fragment 이동으로 확장하면 됩니다.

---

## 2) 테스트 방법

### 준비물 체크
- [ ] 앱 설치 및 실행 가능
- [ ] 알림 권한 허용(팝업 뜨면 허용)
- [ ] 로그캣 열기 + 필터 `UnimateFCM`

---

### Step 1) FCM 토큰 발급 확인
1. 앱 실행
2. Logcat에서 `UnimateFCM` 태그 확인
3. 아래 로그가 찍히는지 확인

- `FCM_TOKEN=xxxx`

✅ 여기까지 되면 “Firebase 연동/토큰 발급”은 성공입니다.

---

### Step 2) 토큰이 백엔드에 등록되는지 확인
1. 앱 실행 후 로그캣에서 토큰 등록 응답 확인
2. 아래처럼 찍히면 성공입니다.

- `토큰 등록 응답 code=200 ...`
- 또는 `✅ 토큰 등록 성공`

❌ 실패한다면
- `토큰 등록 실패(서버 응답 비정상)`
- `토큰 등록 실패(네트워크)`

이 경우는 백엔드 URL/서버 상태/인증 방식(X-USER-ID vs JWT) 확인이 필요합니다.

---

### Step 3) 백엔드(또는 Firebase 콘솔)에서 푸시 보내기
테스트는 **data-only** 방식이 가장 확실합니다.

예시 payload(개념):
```json
{
  "message": {
    "token": "FCM_DEVICE_TOKEN",
    "data": {
      "title": "테스트",
      "body": "푸시 도착",
      "screen": "alarm_detail",
      "alarmId": "1"
    }
  }
}
