### PR TITLE
feat: 알림 api 연동

### DIFF
--- a/app/src/main/java/com/project/unimate/UnimateFirebaseMessagingService.kt
+++ b/app/src/main/java/com/project/unimate/UnimateFirebaseMessagingService.kt
@@ -1,10 +1,13 @@
 package com.project.unimate
 
+import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.media.AudioAttributes
+import android.media.RingtoneManager
 import android.os.Build
 import android.util.Log
 import android.widget.RemoteViews
@@ -71,6 +74,8 @@ class UnimateFirebaseMessagingService : FirebaseMessagingService() {
             .setAutoCancel(true)
             .setContentIntent(pendingIntent)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setDefaults(Notification.DEFAULT_ALL)
+            .setCategory(NotificationCompat.CATEGORY_MESSAGE)
             .build()
 
         val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -106,7 +111,7 @@ class UnimateFirebaseMessagingService : FirebaseMessagingService() {
         )
 
         val contentView = RemoteViews(packageName, R.layout.notification_poke_custom).apply {
-            setTextViewText(R.id.notif_section, "찌르기 $alarmType")
+            setTextViewText(R.id.notif_section, alarmType)
             setTextViewText(R.id.notif_team, teamName)
             setTextViewText(R.id.notif_title, messageTitle)
             setTextViewText(R.id.notif_body, messageBody)
@@ -125,6 +130,8 @@ class UnimateFirebaseMessagingService : FirebaseMessagingService() {
             .setCustomContentView(contentView)
             .setCustomBigContentView(contentView)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setDefaults(Notification.DEFAULT_ALL)
+            .setCategory(NotificationCompat.CATEGORY_MESSAGE)
             .build()
 
         val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -137,14 +144,26 @@ class UnimateFirebaseMessagingService : FirebaseMessagingService() {
         val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         if (nm.getNotificationChannel(CHANNEL_ID) != null) return
 
+        val soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
+        val audioAttrs = AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+            .build()
+
         nm.createNotificationChannel(
-            NotificationChannel(CHANNEL_ID, "Unimate", NotificationManager.IMPORTANCE_HIGH)
+            NotificationChannel(CHANNEL_ID, "Unimate Alerts", NotificationManager.IMPORTANCE_HIGH).apply {
+                description = "Unimate push alerts"
+                enableVibration(true)
+                vibrationPattern = longArrayOf(0, 250, 200, 250)
+                setSound(soundUri, audioAttrs)
+                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+            }
         )
     }
 
     companion object {
         private const val TAG = "UnimateFCM"
-        private const val CHANNEL_ID = "unimate_default"
+        private const val CHANNEL_ID = "unimate_alert_v2"
 
         const val EXTRA_PUSH_SCREEN = "push_screen"
         const val EXTRA_PUSH_ALARM_ID = "push_alarm_id"

--- a/app/src/main/java/com/project/unimate/notification/NotificationItem.kt
+++ b/app/src/main/java/com/project/unimate/notification/NotificationItem.kt
@@ -65,6 +65,7 @@ data class NotificationItem(
             val messageTitle = data["messageTitle"] ?: ""
             val messageBody = data["messageBody"] ?: ""
             val createdAt = data["createdAt"] ?: return null
+            val action = parseBoolean(data["action"]) ?: (alarmType == "MEETING_REQUEST")
 
             return NotificationItem(
                 notificationId = notificationId,
@@ -76,10 +77,18 @@ data class NotificationItem(
                 messageBody = messageBody,
                 createdAt = createdAt,
                 isRead = false,
-                action = true,
+                action = action,
                 actionDone = false,
                 processedAt = null
             )
+        }
+
+        private fun parseBoolean(value: String?): Boolean? {
+            return when (value?.trim()?.lowercase(Locale.US)) {
+                "true", "1", "y", "yes" -> true
+                "false", "0", "n", "no" -> false
+                else -> null
+            }
         }
     }
 }

--- a/app/src/main/java/com/project/unimate/ui/alarm/AlarmFragment.kt
+++ b/app/src/main/java/com/project/unimate/ui/alarm/AlarmFragment.kt
@@ -30,6 +30,9 @@ class AlarmFragment : Fragment() {
         adapter = NotificationAdapter(
             onCompleteClicked = { _, _ ->
                 // 찌르기 탭에서는 알림 액션을 제공하지 않음
+            },
+            onCardClicked = { _, _ ->
+                // 찌르기 탭에서는 카드 읽음 처리를 제공하지 않음
             }
         )
         recyclerView.adapter = adapter

--- a/app/src/main/java/com/project/unimate/ui/alarm/NotificationAdapter.kt
+++ b/app/src/main/java/com/project/unimate/ui/alarm/NotificationAdapter.kt
@@ -13,7 +13,8 @@ import com.project.unimate.notification.NotificationItem
 import com.project.unimate.notification.NotificationUiMapper
 
 class NotificationAdapter(
-    private val onCompleteClicked: (NotificationItem, (NotificationItem) -> Unit) -> Unit
+    private val onCompleteClicked: (NotificationItem, (NotificationItem) -> Unit) -> Unit,
+    private val onCardClicked: (NotificationItem, (NotificationItem) -> Unit) -> Unit
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private val sourceItems = mutableListOf<NotificationItem>()
@@ -59,7 +60,7 @@ class NotificationAdapter(
             SectionHolder(v)
         } else {
             val v = inflater.inflate(R.layout.item_notification_card, parent, false)
-            CardHolder(v, onCompleteClicked)
+            CardHolder(v, onCompleteClicked, onCardClicked)
         }
     }
 
@@ -81,7 +82,8 @@ class NotificationAdapter(
 
     inner class CardHolder(
         itemView: View,
-        private val onCompleteClicked: (NotificationItem, (NotificationItem) -> Unit) -> Unit
+        private val onCompleteClicked: (NotificationItem, (NotificationItem) -> Unit) -> Unit,
+        private val onCardClicked: (NotificationItem, (NotificationItem) -> Unit) -> Unit
     ) : RecyclerView.ViewHolder(itemView) {
         private val dot: View = itemView.findViewById(R.id.team_dot)
         private val teamName: TextView = itemView.findViewById(R.id.team_name)
@@ -128,6 +130,17 @@ class NotificationAdapter(
                     onCompleteClicked(n) { updated ->
                         updateItem(updated)
                     }
+                }
+            }
+
+            itemView.setOnClickListener {
+                if (n.action) {
+                    if (!n.actionDone || n.isRead) return@setOnClickListener
+                } else {
+                    if (n.isRead) return@setOnClickListener
+                }
+                onCardClicked(n) { updated ->
+                    updateItem(updated)
                 }
             }
         }

--- a/app/src/main/java/com/project/unimate/ui/notification/NotificationFragment.kt
+++ b/app/src/main/java/com/project/unimate/ui/notification/NotificationFragment.kt
@@ -29,13 +29,26 @@ class NotificationFragment : Fragment() {
         adapter = NotificationAdapter(
             onCompleteClicked = { item, onResult ->
                 val api = NotificationApi()
-                api.markActionDone(requireContext(), item.notificationId) { success ->
-                    if (success && isAdded) {
-                        val updated = item.copy(actionDone = true)
+                api.markActionDone(requireContext(), item.notificationId) { actionDoneOk ->
+                    if (!actionDoneOk || !isAdded) return@markActionDone
+                    api.markRead(requireContext(), item.notificationId) { readOk ->
+                        if (!isAdded) return@markRead
+                        val updated = item.copy(actionDone = true, isRead = readOk || item.isRead)
                         requireActivity().runOnUiThread {
                             NotificationStore.upsert(requireContext(), updated)
                             onResult(updated)
                         }
+                    }
+                }
+            },
+            onCardClicked = { item, onResult ->
+                val api = NotificationApi()
+                api.markRead(requireContext(), item.notificationId) { success ->
+                    if (!success || !isAdded) return@markRead
+                    val updated = item.copy(isRead = true)
+                    requireActivity().runOnUiThread {
+                        NotificationStore.upsert(requireContext(), updated)
+                        onResult(updated)
                     }
                 }
             }

--- a/app/src/main/java/com/project/unimate/ui/teamspace/TeamShareFragment.kt
+++ b/app/src/main/java/com/project/unimate/ui/teamspace/TeamShareFragment.kt
@@ -1,9 +1,14 @@
 package com.project.unimate.ui.teamspace
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.project.unimate.R
@@ -19,8 +24,23 @@ class TeamShareFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        val inviteCodeView = view.findViewById<TextView>(R.id.tvShareInviteCode)
+
+        fun copyInviteCode() {
+            val code = inviteCodeView.text?.toString()?.trim().orEmpty()
+            if (code.isBlank()) {
+                Toast.makeText(requireContext(), "복사할 초대코드가 없습니다.", Toast.LENGTH_SHORT).show()
+                return
+            }
+            val clipboard = requireContext().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+            clipboard.setPrimaryClip(ClipData.newPlainText("TeamInviteCode", code))
+            Toast.makeText(requireContext(), "초대코드가 복사되었습니다.", Toast.LENGTH_SHORT).show()
+        }
+
         view.findViewById<View>(R.id.teamShareBack).setOnClickListener {
             findNavController().popBackStack()
         }
+        view.findViewById<View>(R.id.btnShareCopyCode).setOnClickListener { copyInviteCode() }
+        view.findViewById<View>(R.id.ivShareCopyIcon).setOnClickListener { copyInviteCode() }
     }
 }


### PR DESCRIPTION
• ## 프론트에서 연동 완료된 알림 API

  ### 1) 내 알림 목록 조회

  - GET /api/notifications
  - 사용처: 알림 화면 진입/재진입 시 서버 알림 동기화

  ### 2) 알림 읽음 처리

  - PATCH /api/notifications/{notificationId}/read
  - 사용처: 알림 카드(액션 없는 알림 포함) 탭하면 읽음 처리되어 회색(완료) 상태로 변경

  ### 3) 알림 액션 완료 처리

  - PATCH /api/notifications/{notificationId}/action-done
  - 사용처: 액션 있는 알림에서 확인 콕누르기 버튼 클릭 시 완료 처리

  ### 4) 액션 알림 버튼 클릭 시 후속 읽음 처리(연동 흐름)

  - 버튼 클릭 시 실행 순서:
      1. PATCH /api/notifications/{notificationId}/action-done
      2. PATCH /api/notifications/{notificationId}/read
  - 목적: 완료 + 읽음까지 처리해서 카드가 회색 상태로 전환됨

  ### 5) (연동은 되어있지만 현재 화면에서 미사용)

  - POST /api/notifications/{notificationId}/complete
  - PATCH /api/notifications/read-all

 ## 알림이 생성/발송되도록 구현된 상황

  ### 팀/멤버 관련

  - 초대코드로 팀 참여 시
      - 팀원들에게: “새 팀원이 참여했어요!” 알림
      - 참여한 본인에게: “팀에 참여했어요!” 알림
  - 팀 탈퇴 시
      - 남아있는 팀원들에게 “팀원이 나갔어요” 알림
  - 팀 종료 시
      - 팀장이 팀 정보를 수정하며 endAt을 오늘/과거로 변경(임의 종료)하면 즉시 알림
      - endAt 날짜가 도달하면(스케줄러) 알림

  ### 모이기(시간투표) 관련

  - 모이기 생성 시(POST /api/schedule-polls)
      - 생성자에게: MEETING_CREATED 알림(액션 없음)
      - 같은 팀 팀원들에게: MEETING_REQUEST 알림(액션 있음)

  ### 찌르기 관련

  - 찌르기 전송 시 알림 생성/발송

  ### 일정 알림 관련

  - 팀 일정: endAt 기준 alarmMinutes분 전 알림(스케줄러)
  - 개인 일정: endAt 기준 alarmMinutes분 전 알림(스케줄러)
  - 팀 일정 D-알림: 팀 일정 마감일 기준 D-1 / D-3 / D-7 알림(스케줄러)
