### PR TITLE
feat: 모임 알림 유저별 분기점 변화

### DIFF
--- a/app/src/main/java/com/project/unimate/ui/timepick/EditTimepickFragment.kt
+++ b/app/src/main/java/com/project/unimate/ui/timepick/EditTimepickFragment.kt
@@ -18,14 +18,12 @@ import com.project.unimate.R
 import com.project.unimate.data.entity.TaskItem
 import com.project.unimate.data.repository.DummyRepository
 import com.project.unimate.network.RetrofitClient
-import com.project.unimate.network.dto.SchedulePollCreateRequest
-import com.project.unimate.network.service.SchedulePollService
+import com.project.unimate.network.dto.TeamScheduleCreateRequest
+import com.project.unimate.network.service.TeamScheduleService
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Calendar
-import java.util.Date
 import java.util.Locale
-import java.time.ZoneId
 
 class EditTimepickFragment : Fragment() {
 
@@ -227,11 +225,10 @@ class EditTimepickFragment : Fragment() {
             }
         }
 
-        cancelBtn.setOnClickListener {
-            findNavController().popBackStack(R.id.createTimepickFragment, true)
-        }
+        cancelBtn.setOnClickListener { closeAfterEdit() }
         saveBtn.setOnClickListener {
             val title = scheduleName.text.toString().ifBlank { "${team?.name ?: ""} 회의" }
+            val notificationLabel = notificationBtn.text?.toString().orEmpty()
             if (existingTask != null) {
                 val updated = existingTask.copy(
                     title = title,
@@ -241,50 +238,107 @@ class EditTimepickFragment : Fragment() {
                 )
                 DummyRepository.updateTask(updated)
                 DummyRepository.saveSchedulesTo(requireContext())
+                closeAfterEdit()
             } else if (teamId.isNotEmpty()) {
-                val task = TaskItem(
-                    id = "timepick-${teamId}-${System.currentTimeMillis()}",
-                    teamId = teamId,
-                    title = title,
-                    date = editStartCalendar,
-                    startTimeMillis = editStartCalendar.timeInMillis,
-                    endTimeMillis = editEndCalendar.timeInMillis,
-                    isChecked = false,
-                    creatorName = null
-                )
-                DummyRepository.addTask(task)
-                DummyRepository.saveSchedulesTo(requireContext())
-
-                // API 호출 (시간 조율 투표 생성)
                 val numericTeamId = teamId.toLongOrNull()
-                if (numericTeamId != null && TimepickStateHolder.pollId == null) {
-                    viewLifecycleOwner.lifecycleScope.launch {
-                        try {
-                            val dateFmt = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
-                            val timeFmt = SimpleDateFormat("HH:mm", Locale.getDefault())
-                            val dates = TimepickStateHolder.displayDates.map { dateFmt.format(Date(it)) }
-                            val timezone = ZoneId.systemDefault().id
-                            val service = RetrofitClient.create<SchedulePollService>(requireContext())
-                            val response = service.create(SchedulePollCreateRequest(
-                                teamId = numericTeamId,
-                                dates = dates,
-                                startTime = timeFmt.format(Date(editStartCalendar.timeInMillis)),
-                                endTime = timeFmt.format(Date(editEndCalendar.timeInMillis)),
-                                timezone = timezone,
-                                title = title,
-                                slotMinutes = 30
-                            ))
-                            if (response.isSuccessful) {
-                                TimepickStateHolder.pollId = response.body()?.pollId
-                            }
-                        } catch (_: Exception) { }
-                    }
+                if (numericTeamId == null) {
+                    val task = TaskItem(
+                        id = "timepick-${teamId}-${System.currentTimeMillis()}",
+                        teamId = teamId,
+                        title = title,
+                        date = editStartCalendar,
+                        startTimeMillis = editStartCalendar.timeInMillis,
+                        endTimeMillis = editEndCalendar.timeInMillis,
+                        isChecked = false,
+                        creatorName = null,
+                        notificationCategory = notificationLabel.ifBlank { "없음" }
+                    )
+                    DummyRepository.addTask(task)
+                    DummyRepository.saveSchedulesTo(requireContext())
+                    closeAfterEdit()
+                    return@setOnClickListener
                 }
+
+                viewLifecycleOwner.lifecycleScope.launch {
+                    val serverId = createTeamScheduleOnServer(
+                        teamId = numericTeamId,
+                        title = title,
+                        alarmMinutes = alarmMinutesFromLabel(notificationLabel)
+                    )
+                    if (serverId == null) {
+                        android.widget.Toast.makeText(
+                            requireContext(),
+                            "일정 저장에 실패했어요. 다시 시도해주세요.",
+                            android.widget.Toast.LENGTH_SHORT
+                        ).show()
+                        return@launch
+                    }
+
+                    val task = TaskItem(
+                        id = "t-${teamId}-${serverId}",
+                        teamId = teamId,
+                        title = title,
+                        date = editStartCalendar,
+                        startTimeMillis = editStartCalendar.timeInMillis,
+                        endTimeMillis = editEndCalendar.timeInMillis,
+                        isChecked = false,
+                        creatorName = null,
+                        notificationCategory = notificationLabel.ifBlank { "없음" }
+                    )
+                    DummyRepository.addTask(task)
+                    DummyRepository.saveSchedulesTo(requireContext())
+                    closeAfterEdit()
+                }
+            } else {
+                closeAfterEdit()
             }
-            findNavController().popBackStack(R.id.createTimepickFragment, true)
         }
 
         return root
+    }
+
+    private suspend fun createTeamScheduleOnServer(
+        teamId: Long,
+        title: String,
+        alarmMinutes: Int?
+    ): Long? {
+        return try {
+            val isoFmt = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault())
+            val service = RetrofitClient.create<TeamScheduleService>(requireContext())
+            val response = service.create(
+                teamId,
+                TeamScheduleCreateRequest(
+                    title = title,
+                    startAt = isoFmt.format(editStartCalendar.time),
+                    endAt = isoFmt.format(editEndCalendar.time),
+                    category = "MEETING",
+                    alarmMinutes = alarmMinutes
+                )
+            )
+            if (response.isSuccessful) response.body()?.id else null
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun alarmMinutesFromLabel(label: String): Int? {
+        return when (label.trim()) {
+            "5분 전" -> 5
+            "15분 전" -> 15
+            "30분 전" -> 30
+            "1시간 전" -> 60
+            else -> null
+        }
+    }
+
+    private fun closeAfterEdit() {
+        val nav = findNavController()
+        val poppedToCreate = nav.popBackStack(R.id.createTimepickFragment, true)
+        if (poppedToCreate) return
+        val poppedOne = nav.popBackStack()
+        if (!poppedOne) {
+            nav.navigate(R.id.calendarFragment)
+        }
     }
 
     private fun formatTime(cal: Calendar): String {

--- a/app/src/main/java/com/project/unimate/ui/timepick/SelectTimeFragment.kt
+++ b/app/src/main/java/com/project/unimate/ui/timepick/SelectTimeFragment.kt
@@ -15,6 +15,7 @@ import androidx.navigation.fragment.findNavController
 import com.project.unimate.R
 import com.project.unimate.network.RetrofitClient
 import com.project.unimate.network.dto.SchedulePollCreateRequest
+import com.project.unimate.network.dto.SchedulePollVoteUpsertRequest
 import com.project.unimate.network.service.SchedulePollService
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
@@ -161,8 +162,19 @@ class SelectTimeFragment : Fragment() {
                                 )
                             )
                             if (response.isSuccessful) {
-                                TimepickStateHolder.pollId = response.body()?.pollId
-                                findNavController().navigate(R.id.timepickStatusFragment)
+                                val pollId = response.body()?.pollId
+                                if (pollId != null && pollId > 0) {
+                                    TimepickStateHolder.pollId = pollId
+                                    val saved = upsertMyVote(service, pollId, grid.selectedCells)
+                                    if (!saved) {
+                                        Toast.makeText(requireContext(), "선택 시간 저장에 실패했어요. 다시 시도해주세요.", Toast.LENGTH_SHORT).show()
+                                        return@launch
+                                    }
+                                    TimepickPollSync.refreshFromServer(requireContext(), pollId)
+                                    findNavController().navigate(R.id.timepickStatusFragment)
+                                } else {
+                                    Toast.makeText(requireContext(), "모이기 생성에 실패했어요. 다시 시도해주세요.", Toast.LENGTH_SHORT).show()
+                                }
                             } else {
                                 Toast.makeText(requireContext(), "모이기 생성에 실패했어요. 다시 시도해주세요.", Toast.LENGTH_SHORT).show()
                             }
@@ -173,9 +185,71 @@ class SelectTimeFragment : Fragment() {
                     return@setOnClickListener
                 }
             }
-            findNavController().navigate(R.id.timepickStatusFragment)
+            val pollId = TimepickStateHolder.pollId
+            if (pollId != null && pollId > 0) {
+                viewLifecycleOwner.lifecycleScope.launch {
+                    try {
+                        val service = RetrofitClient.create<SchedulePollService>(requireContext())
+                        val saved = upsertMyVote(service, pollId, grid.selectedCells)
+                        if (!saved) {
+                            Toast.makeText(requireContext(), "선택 시간 저장에 실패했어요. 다시 시도해주세요.", Toast.LENGTH_SHORT).show()
+                            return@launch
+                        }
+                        TimepickPollSync.refreshFromServer(requireContext(), pollId)
+                        findNavController().navigate(R.id.timepickStatusFragment)
+                    } catch (_: Exception) {
+                        Toast.makeText(requireContext(), "선택 시간 저장에 실패했어요. 다시 시도해주세요.", Toast.LENGTH_SHORT).show()
+                    }
+                }
+            } else {
+                findNavController().navigate(R.id.timepickStatusFragment)
+            }
         }
 
         return root
+    }
+
+    private suspend fun upsertMyVote(
+        service: SchedulePollService,
+        pollId: Long,
+        selectedCells: Set<Pair<Int, Int>>
+    ): Boolean {
+        val detailResp = service.getDetail(pollId)
+        if (!detailResp.isSuccessful) return false
+        val detail = detailResp.body() ?: return false
+
+        val dateOrder = detail.dates.orEmpty().mapIndexed { index, date -> date to index }.toMap()
+        val startHour = parseHour(detail.startTime) ?: TimepickStateHolder.globalStartHour
+
+        val slotIds = detail.slotDefinitions.orEmpty()
+            .mapNotNull { slot ->
+                val slotId = slot.slotId ?: return@mapNotNull null
+                val date = slot.date ?: return@mapNotNull null
+                val dayIndex = dateOrder[date] ?: return@mapNotNull null
+                val hour = parseHour(slot.startTime) ?: return@mapNotNull null
+                val minute = parseMinute(slot.startTime) ?: 0
+                val slotIndex = (hour - startHour) * 2 + if (minute >= 30) 1 else 0
+                if ((dayIndex to slotIndex) in selectedCells) slotId else null
+            }
+            .distinct()
+            .sorted()
+
+        val voteResp = service.upsertMyVote(
+            pollId,
+            SchedulePollVoteUpsertRequest(slots = slotIds)
+        )
+        return voteResp.isSuccessful
+    }
+
+    private fun parseHour(text: String?): Int? {
+        val t = text?.trim().orEmpty()
+        if (!t.contains(":")) return null
+        return t.substringBefore(":").toIntOrNull()
+    }
+
+    private fun parseMinute(text: String?): Int? {
+        val t = text?.trim().orEmpty()
+        if (!t.contains(":")) return null
+        return t.substringAfter(":").take(2).toIntOrNull()
     }
 }


### PR DESCRIPTION
 ### 모임 알림 이동/동기화

  - 알림 데이터에 meetingPollId, meetingNavigationTarget 저장/파싱 추가
  - 모임 알림 버튼 클릭 시 상태값 기반 이동 분기
      - TIMEPICK_STATUS / TIMEPICK_RESULT / EDIT_TIMEPICK
  - 알림 진입 시 poll 상세 재조회 후 TimepickStateHolder 최신화
  - Status/Result 화면에서 서버 동기화된 멤버/투표/교집합 데이터 우선 반영

  ### 모임 시간 입력 저장

  - SelectTimeFragment 완료 시 내 선택 슬롯을 서버 vote로 저장하도록 보강
      - 생성 직후: upsertMyVote 호출
      - 기존 poll 수정 시: upsertMyVote 갱신 호출

  ### 모임 일정 편집 저장

  - EditTimepickFragment 저장 시 팀 일정 서버 생성(TeamScheduleService.create) 추가
  - 서버 생성 성공 시 서버 ID 기반 로컬 일정 저장
  - 알림 경로 진입 시에도 저장/취소 후 안전한 화면 종료 fallback 추가
